### PR TITLE
update `.gitignore` to include `.vscode` dir when using Visual Studio…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Visual Studio Code
+.vscode/


### PR DESCRIPTION
add `.vscode/` dir for ignoring Visual Studio Code project related files for working with project in Visual Studio Code.