### PR TITLE
Make it harder to gouge printer bed

### DIFF
--- a/BedLeveler.Designer.cs
+++ b/BedLeveler.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace BedLeveler
+﻿using System;
+
+namespace BedLeveler
 {
 	partial class BedLeveler
 	{
@@ -62,6 +64,8 @@
             this.recenterButton = new System.Windows.Forms.Button();
             this.autolevelLabel = new System.Windows.Forms.Label();
             this.autolevelCheckBox = new System.Windows.Forms.CheckBox();
+            this.commandBox = new System.Windows.Forms.TextBox();
+            this.sendCommandButton = new System.Windows.Forms.Button();
             measureEveryUnits = new System.Windows.Forms.Label();
             tabPrinter = new System.Windows.Forms.TabPage();
             heightUnits = new System.Windows.Forms.Label();
@@ -445,11 +449,33 @@
             this.autolevelCheckBox.TabIndex = 7;
             this.autolevelCheckBox.UseVisualStyleBackColor = true;
             // 
-            // BedLeveler
+            // commandBox
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.commandBox.Location = new System.Drawing.Point(12, 464);
+            this.commandBox.Name = "commandBox";
+            this.commandBox.Size = new System.Drawing.Size(210, 20);
+            this.commandBox.TabIndex = 11;
+			this.commandBox.AcceptsReturn = false;
+			this.commandBox.Enter += new EventHandler(this.CommandBox_Enter);
+			this.commandBox.Leave += new EventHandler(this.CommandBox_Leave);
+			// 
+			// sendCommandButton
+			// 
+			this.sendCommandButton.Location = new System.Drawing.Point(228, 463);
+            this.sendCommandButton.Name = "sendCommandButton";
+            this.sendCommandButton.Size = new System.Drawing.Size(42, 23);
+            this.sendCommandButton.TabIndex = 12;
+            this.sendCommandButton.Text = "Send";
+            this.sendCommandButton.UseVisualStyleBackColor = true;
+			this.sendCommandButton.Click += new System.EventHandler(this.SendCommand);
+			// 
+			// BedLeveler
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1084, 800);
+            this.Controls.Add(this.sendCommandButton);
+            this.Controls.Add(this.commandBox);
             this.Controls.Add(tabs);
             this.Controls.Add(measureEveryUnits);
             this.Controls.Add(this.measureEveryText);
@@ -503,5 +529,7 @@
 		private System.Windows.Forms.RichTextBox textCustom;
 		private System.Windows.Forms.Label autolevelLabel;
 		private System.Windows.Forms.CheckBox autolevelCheckBox;
+		private System.Windows.Forms.TextBox commandBox;
+		private System.Windows.Forms.Button sendCommandButton;
 	}
 }

--- a/BedLeveler.Designer.cs
+++ b/BedLeveler.Designer.cs
@@ -29,7 +29,7 @@
 		private void InitializeComponent()
 		{
             System.Windows.Forms.Label measureEveryUnits;
-            System.Windows.Forms.TabPage tabBedSize;
+            System.Windows.Forms.TabPage tabPrinter;
             System.Windows.Forms.Label heightUnits;
             System.Windows.Forms.Label heightLabel;
             System.Windows.Forms.Label widthUnits;
@@ -63,7 +63,7 @@
             this.autolevelLabel = new System.Windows.Forms.Label();
             this.autolevelCheckBox = new System.Windows.Forms.CheckBox();
             measureEveryUnits = new System.Windows.Forms.Label();
-            tabBedSize = new System.Windows.Forms.TabPage();
+            tabPrinter = new System.Windows.Forms.TabPage();
             heightUnits = new System.Windows.Forms.Label();
             heightLabel = new System.Windows.Forms.Label();
             widthUnits = new System.Windows.Forms.Label();
@@ -75,7 +75,7 @@
             minZUnits = new System.Windows.Forms.Label();
             minZLabel = new System.Windows.Forms.Label();
             tabs = new System.Windows.Forms.TabControl();
-            tabBedSize.SuspendLayout();
+            tabPrinter.SuspendLayout();
             tabColors.SuspendLayout();
             tabs.SuspendLayout();
             this.tabDetection.SuspendLayout();
@@ -92,23 +92,23 @@
             measureEveryUnits.TabIndex = 10;
             measureEveryUnits.Text = "mm";
             // 
-            // tabBedSize
+            // tabPrinter
             // 
-            tabBedSize.Controls.Add(this.autolevelCheckBox);
-            tabBedSize.Controls.Add(this.autolevelLabel);
-            tabBedSize.Controls.Add(heightUnits);
-            tabBedSize.Controls.Add(this.heightText);
-            tabBedSize.Controls.Add(heightLabel);
-            tabBedSize.Controls.Add(widthUnits);
-            tabBedSize.Controls.Add(this.widthText);
-            tabBedSize.Controls.Add(widthLabel);
-            tabBedSize.Location = new System.Drawing.Point(4, 22);
-            tabBedSize.Name = "tabBedSize";
-            tabBedSize.Padding = new System.Windows.Forms.Padding(3);
-            tabBedSize.Size = new System.Drawing.Size(254, 127);
-            tabBedSize.TabIndex = 0;
-            tabBedSize.Text = "Bed Size";
-            tabBedSize.UseVisualStyleBackColor = true;
+            tabPrinter.Controls.Add(this.autolevelCheckBox);
+            tabPrinter.Controls.Add(this.autolevelLabel);
+            tabPrinter.Controls.Add(heightUnits);
+            tabPrinter.Controls.Add(this.heightText);
+            tabPrinter.Controls.Add(heightLabel);
+            tabPrinter.Controls.Add(widthUnits);
+            tabPrinter.Controls.Add(this.widthText);
+            tabPrinter.Controls.Add(widthLabel);
+            tabPrinter.Location = new System.Drawing.Point(4, 22);
+            tabPrinter.Name = "tabPrinter";
+            tabPrinter.Padding = new System.Windows.Forms.Padding(3);
+            tabPrinter.Size = new System.Drawing.Size(254, 127);
+            tabPrinter.TabIndex = 0;
+            tabPrinter.Text = "Printer Settings";
+            tabPrinter.UseVisualStyleBackColor = true;
             // 
             // heightUnits
             // 
@@ -245,7 +245,7 @@
             // tabs
             // 
             tabs.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            tabs.Controls.Add(tabBedSize);
+            tabs.Controls.Add(tabPrinter);
             tabs.Controls.Add(tabColors);
             tabs.Controls.Add(this.tabDetection);
             tabs.Location = new System.Drawing.Point(12, 488);
@@ -467,8 +467,8 @@
             this.Name = "BedLeveler";
             this.Text = "Printer Bed Inspector";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.BedLeveler_FormClosing);
-            tabBedSize.ResumeLayout(false);
-            tabBedSize.PerformLayout();
+            tabPrinter.ResumeLayout(false);
+            tabPrinter.PerformLayout();
             tabColors.ResumeLayout(false);
             tabColors.PerformLayout();
             tabs.ResumeLayout(false);

--- a/BedLeveler.Designer.cs
+++ b/BedLeveler.Designer.cs
@@ -60,6 +60,8 @@
             this.setZ5Button = new System.Windows.Forms.Button();
             this.measureCornersButton = new System.Windows.Forms.Button();
             this.recenterButton = new System.Windows.Forms.Button();
+            this.autolevelLabel = new System.Windows.Forms.Label();
+            this.autolevelCheckBox = new System.Windows.Forms.CheckBox();
             measureEveryUnits = new System.Windows.Forms.Label();
             tabBedSize = new System.Windows.Forms.TabPage();
             heightUnits = new System.Windows.Forms.Label();
@@ -92,6 +94,8 @@
             // 
             // tabBedSize
             // 
+            tabBedSize.Controls.Add(this.autolevelCheckBox);
+            tabBedSize.Controls.Add(this.autolevelLabel);
             tabBedSize.Controls.Add(heightUnits);
             tabBedSize.Controls.Add(this.heightText);
             tabBedSize.Controls.Add(heightLabel);
@@ -423,6 +427,24 @@
             this.recenterButton.UseVisualStyleBackColor = true;
             this.recenterButton.Click += new System.EventHandler(this.ClearClicked);
             // 
+            // autolevelLabel
+            // 
+            this.autolevelLabel.AutoSize = true;
+            this.autolevelLabel.Location = new System.Drawing.Point(6, 75);
+            this.autolevelLabel.Name = "autolevelLabel";
+            this.autolevelLabel.Size = new System.Drawing.Size(75, 13);
+            this.autolevelLabel.TabIndex = 6;
+            this.autolevelLabel.Text = "Auto-level bed";
+            // 
+            // autolevelCheckBox
+            // 
+            this.autolevelCheckBox.AutoSize = true;
+            this.autolevelCheckBox.Location = new System.Drawing.Point(88, 75);
+            this.autolevelCheckBox.Name = "autolevelCheckBox";
+            this.autolevelCheckBox.Size = new System.Drawing.Size(15, 14);
+            this.autolevelCheckBox.TabIndex = 7;
+            this.autolevelCheckBox.UseVisualStyleBackColor = true;
+            // 
             // BedLeveler
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -479,5 +501,7 @@
 		private System.Windows.Forms.CheckBox checkMarlin2;
 		private System.Windows.Forms.CheckBox checkMarlin1;
 		private System.Windows.Forms.RichTextBox textCustom;
+		private System.Windows.Forms.Label autolevelLabel;
+		private System.Windows.Forms.CheckBox autolevelCheckBox;
 	}
 }

--- a/BedLeveler.Designer.cs
+++ b/BedLeveler.Designer.cs
@@ -28,432 +28,433 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			System.Windows.Forms.Label measureEveryUnits;
-			System.Windows.Forms.TabPage tabBedSize;
-			System.Windows.Forms.Label heightUnits;
-			System.Windows.Forms.Label heightLabel;
-			System.Windows.Forms.Label widthUnits;
-			System.Windows.Forms.Label widthLabel;
-			System.Windows.Forms.TabPage tabColors;
-			System.Windows.Forms.Label autoColorLabel;
-			System.Windows.Forms.Label maxZUnits;
-			System.Windows.Forms.Label maxZLabel;
-			System.Windows.Forms.Label minZUnits;
-			System.Windows.Forms.Label minZLabel;
-			System.Windows.Forms.TabControl tabs;
-			this.heightText = new System.Windows.Forms.TextBox();
-			this.widthText = new System.Windows.Forms.TextBox();
-			this.maxZText = new System.Windows.Forms.TextBox();
-			this.minZText = new System.Windows.Forms.TextBox();
-			this.tabDetection = new System.Windows.Forms.TabPage();
-			this.checkCustom = new System.Windows.Forms.CheckBox();
-			this.checkMarlin2 = new System.Windows.Forms.CheckBox();
-			this.checkMarlin1 = new System.Windows.Forms.CheckBox();
-			this.textCustom = new System.Windows.Forms.RichTextBox();
-			this.portText = new System.Windows.Forms.TextBox();
-			this.connectButton = new System.Windows.Forms.Button();
-			this.outputText = new System.Windows.Forms.TextBox();
-			this.disconnectButton = new System.Windows.Forms.Button();
-			this.bedPicture = new System.Windows.Forms.PictureBox();
-			this.measureEveryText = new System.Windows.Forms.TextBox();
-			this.measureEveryButton = new System.Windows.Forms.Button();
-			this.setZ5Button = new System.Windows.Forms.Button();
-			this.measureCornersButton = new System.Windows.Forms.Button();
-			this.recenterButton = new System.Windows.Forms.Button();
-			measureEveryUnits = new System.Windows.Forms.Label();
-			tabBedSize = new System.Windows.Forms.TabPage();
-			heightUnits = new System.Windows.Forms.Label();
-			heightLabel = new System.Windows.Forms.Label();
-			widthUnits = new System.Windows.Forms.Label();
-			widthLabel = new System.Windows.Forms.Label();
-			tabColors = new System.Windows.Forms.TabPage();
-			autoColorLabel = new System.Windows.Forms.Label();
-			maxZUnits = new System.Windows.Forms.Label();
-			maxZLabel = new System.Windows.Forms.Label();
-			minZUnits = new System.Windows.Forms.Label();
-			minZLabel = new System.Windows.Forms.Label();
-			tabs = new System.Windows.Forms.TabControl();
-			tabBedSize.SuspendLayout();
-			tabColors.SuspendLayout();
-			tabs.SuspendLayout();
-			this.tabDetection.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.bedPicture)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// measureEveryUnits
-			// 
-			measureEveryUnits.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			measureEveryUnits.AutoSize = true;
-			measureEveryUnits.Location = new System.Drawing.Point(251, 770);
-			measureEveryUnits.Name = "measureEveryUnits";
-			measureEveryUnits.Size = new System.Drawing.Size(23, 13);
-			measureEveryUnits.TabIndex = 10;
-			measureEveryUnits.Text = "mm";
-			// 
-			// tabBedSize
-			// 
-			tabBedSize.Controls.Add(heightUnits);
-			tabBedSize.Controls.Add(this.heightText);
-			tabBedSize.Controls.Add(heightLabel);
-			tabBedSize.Controls.Add(widthUnits);
-			tabBedSize.Controls.Add(this.widthText);
-			tabBedSize.Controls.Add(widthLabel);
-			tabBedSize.Location = new System.Drawing.Point(4, 22);
-			tabBedSize.Name = "tabBedSize";
-			tabBedSize.Padding = new System.Windows.Forms.Padding(3);
-			tabBedSize.Size = new System.Drawing.Size(254, 127);
-			tabBedSize.TabIndex = 0;
-			tabBedSize.Text = "Bed Size";
-			tabBedSize.UseVisualStyleBackColor = true;
-			// 
-			// heightUnits
-			// 
-			heightUnits.AutoSize = true;
-			heightUnits.Location = new System.Drawing.Point(130, 52);
-			heightUnits.Name = "heightUnits";
-			heightUnits.Size = new System.Drawing.Size(23, 13);
-			heightUnits.TabIndex = 5;
-			heightUnits.Text = "mm";
-			// 
-			// heightText
-			// 
-			this.heightText.Location = new System.Drawing.Point(75, 49);
-			this.heightText.Name = "heightText";
-			this.heightText.Size = new System.Drawing.Size(49, 20);
-			this.heightText.TabIndex = 4;
-			this.heightText.Text = "150";
-			this.heightText.TextChanged += new System.EventHandler(this.RedrawBedImage);
-			// 
-			// heightLabel
-			// 
-			heightLabel.AutoSize = true;
-			heightLabel.Location = new System.Drawing.Point(6, 52);
-			heightLabel.Name = "heightLabel";
-			heightLabel.Size = new System.Drawing.Size(63, 13);
-			heightLabel.TabIndex = 3;
-			heightLabel.Text = "Bed Height:";
-			// 
-			// widthUnits
-			// 
-			widthUnits.AutoSize = true;
-			widthUnits.Location = new System.Drawing.Point(130, 26);
-			widthUnits.Name = "widthUnits";
-			widthUnits.Size = new System.Drawing.Size(23, 13);
-			widthUnits.TabIndex = 2;
-			widthUnits.Text = "mm";
-			// 
-			// widthText
-			// 
-			this.widthText.Location = new System.Drawing.Point(75, 23);
-			this.widthText.Name = "widthText";
-			this.widthText.Size = new System.Drawing.Size(49, 20);
-			this.widthText.TabIndex = 1;
-			this.widthText.Text = "150";
-			this.widthText.TextChanged += new System.EventHandler(this.RedrawBedImage);
-			// 
-			// widthLabel
-			// 
-			widthLabel.AutoSize = true;
-			widthLabel.Location = new System.Drawing.Point(6, 26);
-			widthLabel.Name = "widthLabel";
-			widthLabel.Size = new System.Drawing.Size(60, 13);
-			widthLabel.TabIndex = 0;
-			widthLabel.Text = "Bed Width:";
-			// 
-			// tabColors
-			// 
-			tabColors.Controls.Add(autoColorLabel);
-			tabColors.Controls.Add(maxZUnits);
-			tabColors.Controls.Add(this.maxZText);
-			tabColors.Controls.Add(maxZLabel);
-			tabColors.Controls.Add(minZUnits);
-			tabColors.Controls.Add(this.minZText);
-			tabColors.Controls.Add(minZLabel);
-			tabColors.Location = new System.Drawing.Point(4, 22);
-			tabColors.Name = "tabColors";
-			tabColors.Padding = new System.Windows.Forms.Padding(3);
-			tabColors.Size = new System.Drawing.Size(254, 127);
-			tabColors.TabIndex = 1;
-			tabColors.Text = "Colors";
-			tabColors.UseVisualStyleBackColor = true;
-			// 
-			// autoColorLabel
-			// 
-			autoColorLabel.AutoSize = true;
-			autoColorLabel.Location = new System.Drawing.Point(6, 70);
-			autoColorLabel.Name = "autoColorLabel";
-			autoColorLabel.Size = new System.Drawing.Size(161, 13);
-			autoColorLabel.TabIndex = 6;
-			autoColorLabel.Text = "Leave blank for automatic colors";
-			// 
-			// maxZUnits
-			// 
-			maxZUnits.AutoSize = true;
-			maxZUnits.Location = new System.Drawing.Point(168, 43);
-			maxZUnits.Name = "maxZUnits";
-			maxZUnits.Size = new System.Drawing.Size(23, 13);
-			maxZUnits.TabIndex = 5;
-			maxZUnits.Text = "mm";
-			// 
-			// maxZText
-			// 
-			this.maxZText.Location = new System.Drawing.Point(113, 40);
-			this.maxZText.Name = "maxZText";
-			this.maxZText.Size = new System.Drawing.Size(49, 20);
-			this.maxZText.TabIndex = 4;
-			this.maxZText.TextChanged += new System.EventHandler(this.RedrawBedImage);
-			// 
-			// maxZLabel
-			// 
-			maxZLabel.AutoSize = true;
-			maxZLabel.Location = new System.Drawing.Point(6, 43);
-			maxZLabel.Name = "maxZLabel";
-			maxZLabel.Size = new System.Drawing.Size(95, 13);
-			maxZLabel.TabIndex = 3;
-			maxZLabel.Text = "Force max Z color:";
-			// 
-			// minZUnits
-			// 
-			minZUnits.AutoSize = true;
-			minZUnits.Location = new System.Drawing.Point(168, 17);
-			minZUnits.Name = "minZUnits";
-			minZUnits.Size = new System.Drawing.Size(23, 13);
-			minZUnits.TabIndex = 2;
-			minZUnits.Text = "mm";
-			// 
-			// minZText
-			// 
-			this.minZText.Location = new System.Drawing.Point(113, 14);
-			this.minZText.Name = "minZText";
-			this.minZText.Size = new System.Drawing.Size(49, 20);
-			this.minZText.TabIndex = 1;
-			this.minZText.TextChanged += new System.EventHandler(this.RedrawBedImage);
-			// 
-			// minZLabel
-			// 
-			minZLabel.AutoSize = true;
-			minZLabel.Location = new System.Drawing.Point(6, 17);
-			minZLabel.Name = "minZLabel";
-			minZLabel.Size = new System.Drawing.Size(92, 13);
-			minZLabel.TabIndex = 0;
-			minZLabel.Text = "Force min Z color:";
-			// 
-			// tabs
-			// 
-			tabs.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			tabs.Controls.Add(tabBedSize);
-			tabs.Controls.Add(tabColors);
-			tabs.Controls.Add(this.tabDetection);
-			tabs.Location = new System.Drawing.Point(12, 488);
-			tabs.Name = "tabs";
-			tabs.SelectedIndex = 0;
-			tabs.Size = new System.Drawing.Size(262, 153);
-			tabs.TabIndex = 4;
-			// 
-			// tabDetection
-			// 
-			this.tabDetection.Controls.Add(this.checkCustom);
-			this.tabDetection.Controls.Add(this.checkMarlin2);
-			this.tabDetection.Controls.Add(this.checkMarlin1);
-			this.tabDetection.Controls.Add(this.textCustom);
-			this.tabDetection.Location = new System.Drawing.Point(4, 22);
-			this.tabDetection.Name = "tabDetection";
-			this.tabDetection.Size = new System.Drawing.Size(254, 127);
-			this.tabDetection.TabIndex = 2;
-			this.tabDetection.Text = "Detection";
-			this.tabDetection.UseVisualStyleBackColor = true;
-			// 
-			// checkCustom
-			// 
-			this.checkCustom.AutoSize = true;
-			this.checkCustom.Location = new System.Drawing.Point(6, 63);
-			this.checkCustom.Name = "checkCustom";
-			this.checkCustom.Size = new System.Drawing.Size(61, 17);
-			this.checkCustom.TabIndex = 2;
-			this.checkCustom.Text = "Custom";
-			this.checkCustom.UseVisualStyleBackColor = true;
-			this.checkCustom.CheckedChanged += new System.EventHandler(this.CheckCustomChanged);
-			// 
-			// checkMarlin2
-			// 
-			this.checkMarlin2.AutoSize = true;
-			this.checkMarlin2.Checked = true;
-			this.checkMarlin2.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.checkMarlin2.Location = new System.Drawing.Point(6, 40);
-			this.checkMarlin2.Name = "checkMarlin2";
-			this.checkMarlin2.Size = new System.Drawing.Size(71, 17);
-			this.checkMarlin2.TabIndex = 1;
-			this.checkMarlin2.Text = "Marlin 2.x";
-			this.checkMarlin2.UseVisualStyleBackColor = true;
-			this.checkMarlin2.CheckedChanged += new System.EventHandler(this.RedrawBedImage);
-			// 
-			// checkMarlin1
-			// 
-			this.checkMarlin1.AutoSize = true;
-			this.checkMarlin1.Checked = true;
-			this.checkMarlin1.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.checkMarlin1.Location = new System.Drawing.Point(6, 17);
-			this.checkMarlin1.Name = "checkMarlin1";
-			this.checkMarlin1.Size = new System.Drawing.Size(71, 17);
-			this.checkMarlin1.TabIndex = 0;
-			this.checkMarlin1.Text = "Marlin 1.x";
-			this.checkMarlin1.UseVisualStyleBackColor = true;
-			this.checkMarlin1.CheckedChanged += new System.EventHandler(this.RedrawBedImage);
-			// 
-			// textCustom
-			// 
-			this.textCustom.DetectUrls = false;
-			this.textCustom.Enabled = false;
-			this.textCustom.Font = new System.Drawing.Font("Courier New", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.textCustom.Location = new System.Drawing.Point(23, 86);
-			this.textCustom.Multiline = false;
-			this.textCustom.Name = "textCustom";
-			this.textCustom.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-			this.textCustom.ShortcutsEnabled = false;
-			this.textCustom.Size = new System.Drawing.Size(220, 22);
-			this.textCustom.TabIndex = 3;
-			this.textCustom.Text = "Bed X: {X} Y: {Y} Z: {Z}";
-			this.textCustom.WordWrap = false;
-			this.textCustom.TextChanged += new System.EventHandler(this.CustomDetectionChanged);
-			// 
-			// portText
-			// 
-			this.portText.Location = new System.Drawing.Point(12, 14);
-			this.portText.Name = "portText";
-			this.portText.Size = new System.Drawing.Size(100, 20);
-			this.portText.TabIndex = 0;
-			// 
-			// connectButton
-			// 
-			this.connectButton.Location = new System.Drawing.Point(118, 12);
-			this.connectButton.Name = "connectButton";
-			this.connectButton.Size = new System.Drawing.Size(75, 23);
-			this.connectButton.TabIndex = 1;
-			this.connectButton.Text = "&Connect";
-			this.connectButton.UseVisualStyleBackColor = true;
-			this.connectButton.Click += new System.EventHandler(this.ConnectButton_Click);
-			// 
-			// outputText
-			// 
-			this.outputText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-				| System.Windows.Forms.AnchorStyles.Left)));
-			this.outputText.Location = new System.Drawing.Point(12, 41);
-			this.outputText.Multiline = true;
-			this.outputText.Name = "outputText";
-			this.outputText.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-			this.outputText.Size = new System.Drawing.Size(262, 416);
-			this.outputText.TabIndex = 3;
-			// 
-			// disconnectButton
-			// 
-			this.disconnectButton.Enabled = false;
-			this.disconnectButton.Location = new System.Drawing.Point(199, 12);
-			this.disconnectButton.Name = "disconnectButton";
-			this.disconnectButton.Size = new System.Drawing.Size(75, 23);
-			this.disconnectButton.TabIndex = 2;
-			this.disconnectButton.Text = "&Disconnect";
-			this.disconnectButton.UseVisualStyleBackColor = true;
-			this.disconnectButton.Click += new System.EventHandler(this.DisconnectButton_Click);
-			// 
-			// bedPicture
-			// 
-			this.bedPicture.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-				| System.Windows.Forms.AnchorStyles.Left)
-				| System.Windows.Forms.AnchorStyles.Right)));
-			this.bedPicture.Location = new System.Drawing.Point(284, 0);
-			this.bedPicture.Name = "bedPicture";
-			this.bedPicture.Size = new System.Drawing.Size(800, 800);
-			this.bedPicture.TabIndex = 5;
-			this.bedPicture.TabStop = false;
-			this.bedPicture.Paint += new System.Windows.Forms.PaintEventHandler(this.BedPaint);
-			this.bedPicture.MouseClick += new System.Windows.Forms.MouseEventHandler(this.BedClick);
-			this.bedPicture.Resize += new System.EventHandler(this.RedrawBedImage);
-			// 
-			// measureEveryText
-			// 
-			this.measureEveryText.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.measureEveryText.Location = new System.Drawing.Point(196, 767);
-			this.measureEveryText.Name = "measureEveryText";
-			this.measureEveryText.Size = new System.Drawing.Size(49, 20);
-			this.measureEveryText.TabIndex = 9;
-			this.measureEveryText.Text = "10";
-			// 
-			// measureEveryButton
-			// 
-			this.measureEveryButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.measureEveryButton.Location = new System.Drawing.Point(12, 765);
-			this.measureEveryButton.Name = "measureEveryButton";
-			this.measureEveryButton.Size = new System.Drawing.Size(178, 23);
-			this.measureEveryButton.TabIndex = 8;
-			this.measureEveryButton.Text = "Measure every:";
-			this.measureEveryButton.UseVisualStyleBackColor = true;
-			this.measureEveryButton.Click += new System.EventHandler(this.GeneratePattern);
-			// 
-			// setZ5Button
-			// 
-			this.setZ5Button.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.setZ5Button.Location = new System.Drawing.Point(12, 689);
-			this.setZ5Button.Name = "setZ5Button";
-			this.setZ5Button.Size = new System.Drawing.Size(262, 23);
-			this.setZ5Button.TabIndex = 6;
-			this.setZ5Button.Text = "Move Z to 5.0mm";
-			this.setZ5Button.UseVisualStyleBackColor = true;
-			this.setZ5Button.Click += new System.EventHandler(this.SetZto5);
-			// 
-			// measureCornersButton
-			// 
-			this.measureCornersButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.measureCornersButton.Location = new System.Drawing.Point(12, 736);
-			this.measureCornersButton.Name = "measureCornersButton";
-			this.measureCornersButton.Size = new System.Drawing.Size(262, 23);
-			this.measureCornersButton.TabIndex = 7;
-			this.measureCornersButton.Text = "Measure corners";
-			this.measureCornersButton.UseVisualStyleBackColor = true;
-			this.measureCornersButton.Click += new System.EventHandler(this.MeasureCorners);
-			// 
-			// recenterButton
-			// 
-			this.recenterButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.recenterButton.Location = new System.Drawing.Point(12, 660);
-			this.recenterButton.Name = "recenterButton";
-			this.recenterButton.Size = new System.Drawing.Size(262, 23);
-			this.recenterButton.TabIndex = 5;
-			this.recenterButton.Text = "Clear and return to center";
-			this.recenterButton.UseVisualStyleBackColor = true;
-			this.recenterButton.Click += new System.EventHandler(this.ClearClicked);
-			// 
-			// BedLeveler
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(1084, 800);
-			this.Controls.Add(tabs);
-			this.Controls.Add(measureEveryUnits);
-			this.Controls.Add(this.measureEveryText);
-			this.Controls.Add(this.measureEveryButton);
-			this.Controls.Add(this.setZ5Button);
-			this.Controls.Add(this.measureCornersButton);
-			this.Controls.Add(this.recenterButton);
-			this.Controls.Add(this.bedPicture);
-			this.Controls.Add(this.disconnectButton);
-			this.Controls.Add(this.outputText);
-			this.Controls.Add(this.connectButton);
-			this.Controls.Add(this.portText);
-			this.DoubleBuffered = true;
-			this.MinimumSize = new System.Drawing.Size(740, 490);
-			this.Name = "BedLeveler";
-			this.Text = "Printer Bed Inspector";
-			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.BedLeveler_FormClosing);
-			tabBedSize.ResumeLayout(false);
-			tabBedSize.PerformLayout();
-			tabColors.ResumeLayout(false);
-			tabColors.PerformLayout();
-			tabs.ResumeLayout(false);
-			this.tabDetection.ResumeLayout(false);
-			this.tabDetection.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.bedPicture)).EndInit();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            System.Windows.Forms.Label measureEveryUnits;
+            System.Windows.Forms.TabPage tabBedSize;
+            System.Windows.Forms.Label heightUnits;
+            System.Windows.Forms.Label heightLabel;
+            System.Windows.Forms.Label widthUnits;
+            System.Windows.Forms.Label widthLabel;
+            System.Windows.Forms.TabPage tabColors;
+            System.Windows.Forms.Label autoColorLabel;
+            System.Windows.Forms.Label maxZUnits;
+            System.Windows.Forms.Label maxZLabel;
+            System.Windows.Forms.Label minZUnits;
+            System.Windows.Forms.Label minZLabel;
+            System.Windows.Forms.TabControl tabs;
+            this.heightText = new System.Windows.Forms.TextBox();
+            this.widthText = new System.Windows.Forms.TextBox();
+            this.maxZText = new System.Windows.Forms.TextBox();
+            this.minZText = new System.Windows.Forms.TextBox();
+            this.tabDetection = new System.Windows.Forms.TabPage();
+            this.checkCustom = new System.Windows.Forms.CheckBox();
+            this.checkMarlin2 = new System.Windows.Forms.CheckBox();
+            this.checkMarlin1 = new System.Windows.Forms.CheckBox();
+            this.textCustom = new System.Windows.Forms.RichTextBox();
+            this.portText = new System.Windows.Forms.TextBox();
+            this.connectButton = new System.Windows.Forms.Button();
+            this.outputText = new System.Windows.Forms.TextBox();
+            this.disconnectButton = new System.Windows.Forms.Button();
+            this.bedPicture = new System.Windows.Forms.PictureBox();
+            this.measureEveryText = new System.Windows.Forms.TextBox();
+            this.measureEveryButton = new System.Windows.Forms.Button();
+            this.setZ5Button = new System.Windows.Forms.Button();
+            this.measureCornersButton = new System.Windows.Forms.Button();
+            this.recenterButton = new System.Windows.Forms.Button();
+            measureEveryUnits = new System.Windows.Forms.Label();
+            tabBedSize = new System.Windows.Forms.TabPage();
+            heightUnits = new System.Windows.Forms.Label();
+            heightLabel = new System.Windows.Forms.Label();
+            widthUnits = new System.Windows.Forms.Label();
+            widthLabel = new System.Windows.Forms.Label();
+            tabColors = new System.Windows.Forms.TabPage();
+            autoColorLabel = new System.Windows.Forms.Label();
+            maxZUnits = new System.Windows.Forms.Label();
+            maxZLabel = new System.Windows.Forms.Label();
+            minZUnits = new System.Windows.Forms.Label();
+            minZLabel = new System.Windows.Forms.Label();
+            tabs = new System.Windows.Forms.TabControl();
+            tabBedSize.SuspendLayout();
+            tabColors.SuspendLayout();
+            tabs.SuspendLayout();
+            this.tabDetection.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.bedPicture)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // measureEveryUnits
+            // 
+            measureEveryUnits.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            measureEveryUnits.AutoSize = true;
+            measureEveryUnits.Location = new System.Drawing.Point(251, 770);
+            measureEveryUnits.Name = "measureEveryUnits";
+            measureEveryUnits.Size = new System.Drawing.Size(23, 13);
+            measureEveryUnits.TabIndex = 10;
+            measureEveryUnits.Text = "mm";
+            // 
+            // tabBedSize
+            // 
+            tabBedSize.Controls.Add(heightUnits);
+            tabBedSize.Controls.Add(this.heightText);
+            tabBedSize.Controls.Add(heightLabel);
+            tabBedSize.Controls.Add(widthUnits);
+            tabBedSize.Controls.Add(this.widthText);
+            tabBedSize.Controls.Add(widthLabel);
+            tabBedSize.Location = new System.Drawing.Point(4, 22);
+            tabBedSize.Name = "tabBedSize";
+            tabBedSize.Padding = new System.Windows.Forms.Padding(3);
+            tabBedSize.Size = new System.Drawing.Size(254, 127);
+            tabBedSize.TabIndex = 0;
+            tabBedSize.Text = "Bed Size";
+            tabBedSize.UseVisualStyleBackColor = true;
+            // 
+            // heightUnits
+            // 
+            heightUnits.AutoSize = true;
+            heightUnits.Location = new System.Drawing.Point(130, 52);
+            heightUnits.Name = "heightUnits";
+            heightUnits.Size = new System.Drawing.Size(23, 13);
+            heightUnits.TabIndex = 5;
+            heightUnits.Text = "mm";
+            // 
+            // heightText
+            // 
+            this.heightText.Location = new System.Drawing.Point(75, 49);
+            this.heightText.Name = "heightText";
+            this.heightText.Size = new System.Drawing.Size(49, 20);
+            this.heightText.TabIndex = 4;
+            this.heightText.Text = "150";
+            this.heightText.TextChanged += new System.EventHandler(this.RedrawBedImage);
+            // 
+            // heightLabel
+            // 
+            heightLabel.AutoSize = true;
+            heightLabel.Location = new System.Drawing.Point(6, 52);
+            heightLabel.Name = "heightLabel";
+            heightLabel.Size = new System.Drawing.Size(63, 13);
+            heightLabel.TabIndex = 3;
+            heightLabel.Text = "Bed Height:";
+            // 
+            // widthUnits
+            // 
+            widthUnits.AutoSize = true;
+            widthUnits.Location = new System.Drawing.Point(130, 26);
+            widthUnits.Name = "widthUnits";
+            widthUnits.Size = new System.Drawing.Size(23, 13);
+            widthUnits.TabIndex = 2;
+            widthUnits.Text = "mm";
+            // 
+            // widthText
+            // 
+            this.widthText.Location = new System.Drawing.Point(75, 23);
+            this.widthText.Name = "widthText";
+            this.widthText.Size = new System.Drawing.Size(49, 20);
+            this.widthText.TabIndex = 1;
+            this.widthText.Text = "150";
+            this.widthText.TextChanged += new System.EventHandler(this.RedrawBedImage);
+            // 
+            // widthLabel
+            // 
+            widthLabel.AutoSize = true;
+            widthLabel.Location = new System.Drawing.Point(6, 26);
+            widthLabel.Name = "widthLabel";
+            widthLabel.Size = new System.Drawing.Size(60, 13);
+            widthLabel.TabIndex = 0;
+            widthLabel.Text = "Bed Width:";
+            // 
+            // tabColors
+            // 
+            tabColors.Controls.Add(autoColorLabel);
+            tabColors.Controls.Add(maxZUnits);
+            tabColors.Controls.Add(this.maxZText);
+            tabColors.Controls.Add(maxZLabel);
+            tabColors.Controls.Add(minZUnits);
+            tabColors.Controls.Add(this.minZText);
+            tabColors.Controls.Add(minZLabel);
+            tabColors.Location = new System.Drawing.Point(4, 22);
+            tabColors.Name = "tabColors";
+            tabColors.Padding = new System.Windows.Forms.Padding(3);
+            tabColors.Size = new System.Drawing.Size(254, 127);
+            tabColors.TabIndex = 1;
+            tabColors.Text = "Colors";
+            tabColors.UseVisualStyleBackColor = true;
+            // 
+            // autoColorLabel
+            // 
+            autoColorLabel.AutoSize = true;
+            autoColorLabel.Location = new System.Drawing.Point(6, 70);
+            autoColorLabel.Name = "autoColorLabel";
+            autoColorLabel.Size = new System.Drawing.Size(161, 13);
+            autoColorLabel.TabIndex = 6;
+            autoColorLabel.Text = "Leave blank for automatic colors";
+            // 
+            // maxZUnits
+            // 
+            maxZUnits.AutoSize = true;
+            maxZUnits.Location = new System.Drawing.Point(168, 43);
+            maxZUnits.Name = "maxZUnits";
+            maxZUnits.Size = new System.Drawing.Size(23, 13);
+            maxZUnits.TabIndex = 5;
+            maxZUnits.Text = "mm";
+            // 
+            // maxZText
+            // 
+            this.maxZText.Location = new System.Drawing.Point(113, 40);
+            this.maxZText.Name = "maxZText";
+            this.maxZText.Size = new System.Drawing.Size(49, 20);
+            this.maxZText.TabIndex = 4;
+            this.maxZText.TextChanged += new System.EventHandler(this.RedrawBedImage);
+            // 
+            // maxZLabel
+            // 
+            maxZLabel.AutoSize = true;
+            maxZLabel.Location = new System.Drawing.Point(6, 43);
+            maxZLabel.Name = "maxZLabel";
+            maxZLabel.Size = new System.Drawing.Size(95, 13);
+            maxZLabel.TabIndex = 3;
+            maxZLabel.Text = "Force max Z color:";
+            // 
+            // minZUnits
+            // 
+            minZUnits.AutoSize = true;
+            minZUnits.Location = new System.Drawing.Point(168, 17);
+            minZUnits.Name = "minZUnits";
+            minZUnits.Size = new System.Drawing.Size(23, 13);
+            minZUnits.TabIndex = 2;
+            minZUnits.Text = "mm";
+            // 
+            // minZText
+            // 
+            this.minZText.Location = new System.Drawing.Point(113, 14);
+            this.minZText.Name = "minZText";
+            this.minZText.Size = new System.Drawing.Size(49, 20);
+            this.minZText.TabIndex = 1;
+            this.minZText.TextChanged += new System.EventHandler(this.RedrawBedImage);
+            // 
+            // minZLabel
+            // 
+            minZLabel.AutoSize = true;
+            minZLabel.Location = new System.Drawing.Point(6, 17);
+            minZLabel.Name = "minZLabel";
+            minZLabel.Size = new System.Drawing.Size(92, 13);
+            minZLabel.TabIndex = 0;
+            minZLabel.Text = "Force min Z color:";
+            // 
+            // tabs
+            // 
+            tabs.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            tabs.Controls.Add(tabBedSize);
+            tabs.Controls.Add(tabColors);
+            tabs.Controls.Add(this.tabDetection);
+            tabs.Location = new System.Drawing.Point(12, 488);
+            tabs.Name = "tabs";
+            tabs.SelectedIndex = 0;
+            tabs.Size = new System.Drawing.Size(262, 153);
+            tabs.TabIndex = 4;
+            // 
+            // tabDetection
+            // 
+            this.tabDetection.Controls.Add(this.checkCustom);
+            this.tabDetection.Controls.Add(this.checkMarlin2);
+            this.tabDetection.Controls.Add(this.checkMarlin1);
+            this.tabDetection.Controls.Add(this.textCustom);
+            this.tabDetection.Location = new System.Drawing.Point(4, 22);
+            this.tabDetection.Name = "tabDetection";
+            this.tabDetection.Size = new System.Drawing.Size(254, 127);
+            this.tabDetection.TabIndex = 2;
+            this.tabDetection.Text = "Detection";
+            this.tabDetection.UseVisualStyleBackColor = true;
+            // 
+            // checkCustom
+            // 
+            this.checkCustom.AutoSize = true;
+            this.checkCustom.Location = new System.Drawing.Point(6, 63);
+            this.checkCustom.Name = "checkCustom";
+            this.checkCustom.Size = new System.Drawing.Size(61, 17);
+            this.checkCustom.TabIndex = 2;
+            this.checkCustom.Text = "Custom";
+            this.checkCustom.UseVisualStyleBackColor = true;
+            this.checkCustom.CheckedChanged += new System.EventHandler(this.CheckCustomChanged);
+            // 
+            // checkMarlin2
+            // 
+            this.checkMarlin2.AutoSize = true;
+            this.checkMarlin2.Checked = true;
+            this.checkMarlin2.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkMarlin2.Location = new System.Drawing.Point(6, 40);
+            this.checkMarlin2.Name = "checkMarlin2";
+            this.checkMarlin2.Size = new System.Drawing.Size(71, 17);
+            this.checkMarlin2.TabIndex = 1;
+            this.checkMarlin2.Text = "Marlin 2.x";
+            this.checkMarlin2.UseVisualStyleBackColor = true;
+            this.checkMarlin2.CheckedChanged += new System.EventHandler(this.RedrawBedImage);
+            // 
+            // checkMarlin1
+            // 
+            this.checkMarlin1.AutoSize = true;
+            this.checkMarlin1.Checked = true;
+            this.checkMarlin1.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkMarlin1.Location = new System.Drawing.Point(6, 17);
+            this.checkMarlin1.Name = "checkMarlin1";
+            this.checkMarlin1.Size = new System.Drawing.Size(71, 17);
+            this.checkMarlin1.TabIndex = 0;
+            this.checkMarlin1.Text = "Marlin 1.x";
+            this.checkMarlin1.UseVisualStyleBackColor = true;
+            this.checkMarlin1.CheckedChanged += new System.EventHandler(this.RedrawBedImage);
+            // 
+            // textCustom
+            // 
+            this.textCustom.DetectUrls = false;
+            this.textCustom.Enabled = false;
+            this.textCustom.Font = new System.Drawing.Font("Courier New", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.textCustom.Location = new System.Drawing.Point(23, 86);
+            this.textCustom.Multiline = false;
+            this.textCustom.Name = "textCustom";
+            this.textCustom.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
+            this.textCustom.ShortcutsEnabled = false;
+            this.textCustom.Size = new System.Drawing.Size(220, 22);
+            this.textCustom.TabIndex = 3;
+            this.textCustom.Text = "Bed X: {X} Y: {Y} Z: {Z}";
+            this.textCustom.WordWrap = false;
+            this.textCustom.TextChanged += new System.EventHandler(this.CustomDetectionChanged);
+            // 
+            // portText
+            // 
+            this.portText.Location = new System.Drawing.Point(12, 14);
+            this.portText.Name = "portText";
+            this.portText.Size = new System.Drawing.Size(100, 20);
+            this.portText.TabIndex = 0;
+            // 
+            // connectButton
+            // 
+            this.connectButton.Location = new System.Drawing.Point(118, 12);
+            this.connectButton.Name = "connectButton";
+            this.connectButton.Size = new System.Drawing.Size(75, 23);
+            this.connectButton.TabIndex = 1;
+            this.connectButton.Text = "&Connect";
+            this.connectButton.UseVisualStyleBackColor = true;
+            this.connectButton.Click += new System.EventHandler(this.ConnectButton_Click);
+            // 
+            // outputText
+            // 
+            this.outputText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.outputText.Location = new System.Drawing.Point(12, 41);
+            this.outputText.Multiline = true;
+            this.outputText.Name = "outputText";
+            this.outputText.ReadOnly = true;
+            this.outputText.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            this.outputText.Size = new System.Drawing.Size(262, 416);
+            this.outputText.TabIndex = 3;
+            // 
+            // disconnectButton
+            // 
+            this.disconnectButton.Enabled = false;
+            this.disconnectButton.Location = new System.Drawing.Point(199, 12);
+            this.disconnectButton.Name = "disconnectButton";
+            this.disconnectButton.Size = new System.Drawing.Size(75, 23);
+            this.disconnectButton.TabIndex = 2;
+            this.disconnectButton.Text = "&Disconnect";
+            this.disconnectButton.UseVisualStyleBackColor = true;
+            this.disconnectButton.Click += new System.EventHandler(this.DisconnectButton_Click);
+            // 
+            // bedPicture
+            // 
+            this.bedPicture.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.bedPicture.Location = new System.Drawing.Point(284, 0);
+            this.bedPicture.Name = "bedPicture";
+            this.bedPicture.Size = new System.Drawing.Size(800, 800);
+            this.bedPicture.TabIndex = 5;
+            this.bedPicture.TabStop = false;
+            this.bedPicture.Paint += new System.Windows.Forms.PaintEventHandler(this.BedPaint);
+            this.bedPicture.MouseClick += new System.Windows.Forms.MouseEventHandler(this.BedClick);
+            this.bedPicture.Resize += new System.EventHandler(this.RedrawBedImage);
+            // 
+            // measureEveryText
+            // 
+            this.measureEveryText.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.measureEveryText.Location = new System.Drawing.Point(196, 767);
+            this.measureEveryText.Name = "measureEveryText";
+            this.measureEveryText.Size = new System.Drawing.Size(49, 20);
+            this.measureEveryText.TabIndex = 9;
+            this.measureEveryText.Text = "10";
+            // 
+            // measureEveryButton
+            // 
+            this.measureEveryButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.measureEveryButton.Location = new System.Drawing.Point(12, 765);
+            this.measureEveryButton.Name = "measureEveryButton";
+            this.measureEveryButton.Size = new System.Drawing.Size(178, 23);
+            this.measureEveryButton.TabIndex = 8;
+            this.measureEveryButton.Text = "Measure every:";
+            this.measureEveryButton.UseVisualStyleBackColor = true;
+            this.measureEveryButton.Click += new System.EventHandler(this.GeneratePattern);
+            // 
+            // setZ5Button
+            // 
+            this.setZ5Button.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.setZ5Button.Location = new System.Drawing.Point(12, 689);
+            this.setZ5Button.Name = "setZ5Button";
+            this.setZ5Button.Size = new System.Drawing.Size(262, 23);
+            this.setZ5Button.TabIndex = 6;
+            this.setZ5Button.Text = "Move Z to 5.0mm";
+            this.setZ5Button.UseVisualStyleBackColor = true;
+            this.setZ5Button.Click += new System.EventHandler(this.SetZto5);
+            // 
+            // measureCornersButton
+            // 
+            this.measureCornersButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.measureCornersButton.Location = new System.Drawing.Point(12, 736);
+            this.measureCornersButton.Name = "measureCornersButton";
+            this.measureCornersButton.Size = new System.Drawing.Size(262, 23);
+            this.measureCornersButton.TabIndex = 7;
+            this.measureCornersButton.Text = "Measure corners";
+            this.measureCornersButton.UseVisualStyleBackColor = true;
+            this.measureCornersButton.Click += new System.EventHandler(this.MeasureCorners);
+            // 
+            // recenterButton
+            // 
+            this.recenterButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.recenterButton.Location = new System.Drawing.Point(12, 660);
+            this.recenterButton.Name = "recenterButton";
+            this.recenterButton.Size = new System.Drawing.Size(262, 23);
+            this.recenterButton.TabIndex = 5;
+            this.recenterButton.Text = "Clear and return to center";
+            this.recenterButton.UseVisualStyleBackColor = true;
+            this.recenterButton.Click += new System.EventHandler(this.ClearClicked);
+            // 
+            // BedLeveler
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(1084, 800);
+            this.Controls.Add(tabs);
+            this.Controls.Add(measureEveryUnits);
+            this.Controls.Add(this.measureEveryText);
+            this.Controls.Add(this.measureEveryButton);
+            this.Controls.Add(this.setZ5Button);
+            this.Controls.Add(this.measureCornersButton);
+            this.Controls.Add(this.recenterButton);
+            this.Controls.Add(this.bedPicture);
+            this.Controls.Add(this.disconnectButton);
+            this.Controls.Add(this.outputText);
+            this.Controls.Add(this.connectButton);
+            this.Controls.Add(this.portText);
+            this.DoubleBuffered = true;
+            this.MinimumSize = new System.Drawing.Size(740, 490);
+            this.Name = "BedLeveler";
+            this.Text = "Printer Bed Inspector";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.BedLeveler_FormClosing);
+            tabBedSize.ResumeLayout(false);
+            tabBedSize.PerformLayout();
+            tabColors.ResumeLayout(false);
+            tabColors.PerformLayout();
+            tabs.ResumeLayout(false);
+            this.tabDetection.ResumeLayout(false);
+            this.tabDetection.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.bedPicture)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 

--- a/BedLeveler.cs
+++ b/BedLeveler.cs
@@ -341,6 +341,25 @@ namespace BedLeveler
 			MeasureNextPoint();
 		}
 
+		private void SendCommand(object sender, EventArgs e)
+		{
+			if (commandBox.Text.Length > 0)
+			{
+				port.Send(commandBox.Text.Trim());
+				commandBox.ResetText();
+			}
+		}
+
+		private void CommandBox_Enter(object sender, EventArgs e)
+		{
+			ActiveForm.AcceptButton = sendCommandButton;
+		}
+
+		private void CommandBox_Leave(object sender, EventArgs e)
+		{
+			ActiveForm.AcceptButton = null;
+		}
+
 		private void BedLeveler_FormClosing(object sender, FormClosingEventArgs e)
 		{
 			if (port != null)

--- a/BedLeveler.cs
+++ b/BedLeveler.cs
@@ -191,6 +191,10 @@ namespace BedLeveler
 			connectButton.Enabled = false;
 			disconnectButton.Enabled = true;
 
+			port.Send("G21");
+			port.Send("G90"); // absolute positioning
+			port.Send("G1 F9000");
+
 			ClearClicked(this, new EventArgs());
 		}
 

--- a/BedLeveler.cs
+++ b/BedLeveler.cs
@@ -20,7 +20,7 @@ namespace BedLeveler
 		readonly Regex Marlin2 = ParseSimplifiedDetector("Bed X: {X} Y: {Y} Z: {Z}");
 		Regex customDetection = null;
 
-		readonly int zMeasureHeight = 2;
+		readonly int zMeasureHeight = 3;
 		readonly int feedSpeed = 6000;
 		readonly string decimalSeparator = ".";
 		readonly static string systemDecimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
@@ -308,6 +308,7 @@ namespace BedLeveler
 
 			if (port != null)
 			{
+				port.Send("G1 Z2"); //avoid gauging surface
 				port.Send("G28");
 				port.Send("G30");
 			}

--- a/BedLeveler.cs
+++ b/BedLeveler.cs
@@ -310,7 +310,14 @@ namespace BedLeveler
 			{
 				port.Send("G1 Z2"); //avoid gauging surface
 				port.Send("G28");
-				port.Send("G30");
+
+				if (autolevelCheckBox.Checked)
+				{
+					port.Send("G29"); //run auto bed leveling. Must occur AFTER G28
+				}
+
+				var (w, h) = BedDimensions;
+				MeasurePoint(w / 2.0f, h / 2.0f);
 			}
 		}
 

--- a/BedLeveler.cs
+++ b/BedLeveler.cs
@@ -346,13 +346,10 @@ namespace BedLeveler
 			var (valid, w, h) = CheckedDimensions;
 			if (!valid) return;
 
-			if (port != null)
-			{
-				port.Send($"G1 Y{h} X0 Z{zMeasureHeight} {feedSpeed}"); port.Send("G30");
-				port.Send($"G1 X0 Y0 Z{zMeasureHeight} {feedSpeed}"); port.Send("G30");
-				port.Send($"G1 Y0 X{w} Z{zMeasureHeight} {feedSpeed}"); port.Send("G30");
-				port.Send($"G1 Y{h} X{w} Z{zMeasureHeight} {feedSpeed}"); port.Send("G30");
-			}
+			MeasurePoint(0, h);
+			MeasurePoint(0, 0);
+			MeasurePoint(w, 0);
+			MeasurePoint(w, h);
 		}
 
 		private void SetZto5(object sender, EventArgs e)

--- a/BedLeveler.resx
+++ b/BedLeveler.resx
@@ -120,7 +120,7 @@
   <metadata name="measureEveryUnits.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="tabBedSize.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="tabPrinter.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
   <metadata name="heightUnits.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">


### PR DESCRIPTION
My motivation was that i thoroughly wrecked my extremely unleveled printer bed trying to get this program to work. I have added some changes to make this less likely, including:
* Raise bed prior to large movements
* Add support for auto-leveling
* Add command box to allow sending custom commands

Unfortunately visualstudio decided to reformat most of Designer.cs and i couldnt find a way around it.

I am very rusty in C#, let me know if anything needs improving.